### PR TITLE
Support of "docker-compose down" and preparation for "docker-compose" feature 

### DIFF
--- a/docker-compose-plugin/resources/views/task.template.html
+++ b/docker-compose-plugin/resources/views/task.template.html
@@ -68,6 +68,17 @@
     </div>
     <div class="form_item_block">
         <div class="checkbox_row">
+            <input id="COMPOSE_DOWN2" type="checkbox" ng-model="COMPOSE_DOWN2"
+                   ng-init="COMPOSE_DOWN2 = COMPOSE_DOWN"
+                   ng-change="COMPOSE_DOWN = COMPOSE_DOWN2" ng-true-value="true"
+                   ng-false-value="false">
+            <input id="COMPOSE_DOWN" type="hidden" ng-model="COMPOSE_DOWN"
+                   value="{{COMPOSE_DOWN}}">
+            <label>Issue a "compose down" command</label>
+        </div>
+    </div>
+    <div class="form_item_block">
+        <div class="checkbox_row">
             <input id="FORCE_PULL2" type="checkbox" ng-model="FORCE_PULL2" ng-init="FORCE_PULL2 = FORCE_PULL"
                    ng-change="FORCE_PULL = FORCE_PULL2" ng-true-value="true" ng-false-value="false">
             <input id="FORCE_PULL" type="hidden" ng-model="FORCE_PULL" value="{{FORCE_PULL}}">
@@ -98,4 +109,11 @@
             <label>Force recreation of containers (e.g. For restarting init)</label>
         </div>
     </div>
+<!--
+    <div class="form_item_block">
+        <label>Create an deployment bundle (*.dab)</label>
+        <input type="text" ng-model="BUNDLE_OUTPUT_PATH" ng-required="false">
+        </input>
+    </div>
+-->
 </div>

--- a/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeBundleCommand.java
+++ b/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeBundleCommand.java
@@ -1,0 +1,24 @@
+package com.tw.go.task.dockercompose;
+
+import com.thoughtworks.go.plugin.api.task.JobConsoleLogger;
+import com.tw.go.plugin.common.ConfigVars;
+
+import java.io.FileNotFoundException;
+
+/**
+ * Created by thomassc on 08.05.16.
+ */
+public class DockerComposeBundleCommand extends DockerComposeCommand {
+
+    public DockerComposeBundleCommand(JobConsoleLogger console, ConfigVars configVars) throws Exception {
+        super(console, configVars);
+
+        if (configVars.isEmpty(DockerComposeTask.BUNDLE_OUTPUT_PATH)) {
+            throw new Exception("Missing setting for " + DockerComposeTask.BUNDLE_OUTPUT_PATH);
+        }
+
+        add("bundle");
+        add("--output");
+        add(configVars.getValue(DockerComposeTask.BUNDLE_OUTPUT_PATH));
+    }
+}

--- a/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeDownCommand.java
+++ b/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeDownCommand.java
@@ -1,0 +1,25 @@
+package com.tw.go.task.dockercompose;
+
+import com.thoughtworks.go.plugin.api.task.JobConsoleLogger;
+import com.tw.go.plugin.common.ConfigVars;
+
+import java.io.FileNotFoundException;
+
+/**
+ * Created by thomassc on 08.05.16.
+ */
+public class DockerComposeDownCommand extends DockerComposeCommand {
+
+    public DockerComposeDownCommand(JobConsoleLogger console, ConfigVars configVars) throws FileNotFoundException {
+        super(console,configVars);
+
+        add("down");
+        add("--remove-orphans");
+
+        if (configVars.isChecked(DockerComposeTask.COMPOSE_REMOVE_VOLUMES)) {
+            add("-v");
+        }
+
+        //addServiceList(configVars);
+    }
+}

--- a/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposePsCommand.java
+++ b/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposePsCommand.java
@@ -1,0 +1,20 @@
+package com.tw.go.task.dockercompose;
+
+import com.thoughtworks.go.plugin.api.task.JobConsoleLogger;
+import com.tw.go.plugin.common.ConfigVars;
+
+import java.io.FileNotFoundException;
+
+/**
+ * Created by thomassc on 08.05.16.
+ */
+public class DockerComposePsCommand extends DockerComposeCommand {
+
+    public DockerComposePsCommand(JobConsoleLogger console, ConfigVars configVars) throws FileNotFoundException {
+        super(console,configVars);
+
+        add("ps");
+
+        addServiceList(configVars);
+    }
+}

--- a/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeTask.java
+++ b/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeTask.java
@@ -23,8 +23,10 @@ public class DockerComposeTask extends BaseGoPlugin {
     public static final String FORCE_BUILD = "FORCE_BUILD";
     public static final String COMPOSE_NO_CACHE = "COMPOSE_NO_CACHE";
     public static final String COMPOSE_REMOVE_VOLUMES = "COMPOSE_REMOVE_VOLUMES";
+    public static final String COMPOSE_DOWN = "COMPOSE_DOWN";
     public static final String FORCE_PULL = "FORCE_PULL";
     public static final String FORCE_BUILD_ONLY = "FORCE_BUILD_ONLY";
+    public static final String BUNDLE_OUTPUT_PATH = "BUNDLE_OUTPUT_PATH";
 
     @Override
     protected GoPluginApiResponse handleGetConfigRequest(GoPluginApiRequest request) {
@@ -38,8 +40,10 @@ public class DockerComposeTask extends BaseGoPlugin {
                 .add(FORCE_BUILD, "false", Required.NO)
                 .add(COMPOSE_NO_CACHE, "false", Required.NO)
                 .add(COMPOSE_REMOVE_VOLUMES, "false", Required.NO)
+                .add(COMPOSE_DOWN, "false", Required.NO)
                 .add(FORCE_PULL, "false", Required.NO)
                 .add(FORCE_BUILD_ONLY, "false", Required.NO)
+                .add(BUNDLE_OUTPUT_PATH, "", Required.NO)
                 .toMap());
     }
 

--- a/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeTaskExecutor.java
+++ b/docker-compose-plugin/src/com/tw/go/task/dockercompose/DockerComposeTaskExecutor.java
@@ -28,7 +28,13 @@ public class DockerComposeTaskExecutor extends TaskExecutor {
     @Override
     public Result execute() throws Exception {
         try {
+            if (configVars.isChecked(DockerComposeTask.COMPOSE_DOWN)) {
+                new DockerComposeDownCommand(console, configVars)
+                        .run();
+            }
             if (configVars.isChecked(DockerComposeTask.COMPOSE_REMOVE_VOLUMES)) {
+                new DockerComposePsCommand(console, configVars)
+                        .run();
                 new DockerComposeStopCommand(console, configVars)
                         .run();
                 new DockerComposeRmCommand(console, configVars)
@@ -42,8 +48,14 @@ public class DockerComposeTaskExecutor extends TaskExecutor {
                 new DockerComposeBuildCommand(console, configVars)
                         .run();
             }
+            if (!configVars.isEmpty(DockerComposeTask.BUNDLE_OUTPUT_PATH)) {
+                new DockerComposeBundleCommand(console, configVars)
+                        .run();
+            }
             if (!configVars.isChecked(DockerComposeTask.FORCE_BUILD_ONLY)) {
                 new DockerComposeUpCommand(console, configVars)
+                        .run();
+                new DockerComposePsCommand(console, configVars)
                         .run();
             }
         } catch (Exception e) {


### PR DESCRIPTION
the down command is REQUIRED to cleanly recreate networks during deployment.
the bundle feature might be handy, if it goes out of "experimental"
