### PR TITLE
Support for new SonarQube versions - 5.3 and later

### DIFF
--- a/sonar-qualitygates-plugin/pom.xml
+++ b/sonar-qualitygates-plugin/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.thoughtworks.go</groupId>
     <artifactId>gocd-sonar-qualitygates-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.thoughtworks.go</groupId>
             <artifactId>gocd-plugin-common</artifactId>
-            <version>${project.version}</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarClient.java
+++ b/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarClient.java
@@ -20,12 +20,11 @@ public class SonarClient extends ApiRequestBase {
 
     public JSONObject getProjectWithQualityGateDetails(String projectKey) throws Exception
     {
-        String uri = getApiUrl() + "/resources?resource=%1$s&metrics=quality_gate_details";
+        String uri = getApiUrl() + "/qualitygates/project_status?projectKey=%1$s";
         uri = String.format(uri, projectKey);
         String resultData = requestGet(uri);
 
-        JSONArray jsonArray = new JSONArray(resultData);
-        JSONObject jsonObject = jsonArray.getJSONObject(0);
+        JSONObject jsonObject = new JSONObject(resultData);
 
         return jsonObject;
     }

--- a/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarParser.java
+++ b/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarParser.java
@@ -1,6 +1,5 @@
 package com.tw.go.task.sonarqualitygate;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 /**
@@ -14,27 +13,13 @@ public class SonarParser
         this.project = projectResult;
     }
 
-    public JSONObject GetQualityGateDetails()
+    public String getProjectQualityGateStatus()
     {
-        if (project.has("msr")) {
-            JSONArray msrList = project.getJSONArray("msr");
-
-            for (int i = 0; i < msrList.length(); i++)
-            {
-                JSONObject msr = (JSONObject) msrList.get(i);
-                String key = msr.getString("key");
-
-                if("quality_gate_details".equals(key))
-                {
-                    String data = msr.getString("data");
-                    //data = data.replace("\\", "");
-                    JSONObject resultObj = new JSONObject(data);
-                    return resultObj;
-                }
-
+        if (project.has("projectStatus")) {
+            JSONObject projectStatus = project.getJSONObject("projectStatus");
+            if (projectStatus.has("status")) {
+                return projectStatus.getString("status");
             }
-
-
         }
         return null;
     }

--- a/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarTaskExecutor.java
+++ b/sonar-qualitygates-plugin/src/com/tw/go/task/sonarqualitygate/SonarTaskExecutor.java
@@ -88,9 +88,7 @@ public class SonarTaskExecutor extends TaskExecutor {
                 SonarParser parser = new SonarParser(result);
 
                 // check that a quality gate is returned
-                JSONObject qgDetails = parser.GetQualityGateDetails();
-
-                String qgResult = qgDetails.getString("level");
+                String qgResult = parser.getProjectQualityGateStatus();
 
                 // get result issues
                 return parseResult(qgResult, issueTypeFail);
@@ -104,9 +102,7 @@ public class SonarTaskExecutor extends TaskExecutor {
                 SonarParser parser = new SonarParser(result);
 
                 // check that a quality gate is returned
-                JSONObject qgDetails = parser.GetQualityGateDetails();
-
-                String qgResult = qgDetails.getString("level");
+                String qgResult = parser.getProjectQualityGateStatus();
 
                 // get result issues
                 return parseResult(qgResult, issueTypeFail);

--- a/sonar-qualitygates-plugin/test/com/tw/go/task/sonarqualitygate/SonarClientTest.java
+++ b/sonar-qualitygates-plugin/test/com/tw/go/task/sonarqualitygate/SonarClientTest.java
@@ -31,6 +31,7 @@ public class SonarClientTest {
         SonarClientTest.sonarProjectKey = props.getProperty("sonarProjectKey");
     }
 
+    @Test
     public void testQualityGateResult() throws Exception {
 
         // create a sonar client
@@ -42,9 +43,7 @@ public class SonarClientTest {
         SonarParser parser = new SonarParser(result);
 
         // check that a quality gate is returned
-        JSONObject qgDetails = parser.GetQualityGateDetails();
-
-        String qgResult = qgDetails.getString("level");
+        String qgResult = parser.getProjectQualityGateStatus();
         Assert.assertEquals("ERROR", qgResult);
     }
 


### PR DESCRIPTION
/api/resources endpoint was removed in SonarQube 6.3 and later, so this plugin doesn't work with new SonarQube versions

Version upgraded to release version 2.0.0 because it's not compatible with previous version
Plugin use new endpoint /qualitygates/project_status introduced by SonarQube 5.3
For SonarQube prior 5.3 use plugin version 1.x.x
For SonarQube 5.3 and later versions use plugin version >=2.0.0