### PR TITLE
Update guava to 30.1

### DIFF
--- a/fortify-plugin/pom.xml
+++ b/fortify-plugin/pom.xml
@@ -60,14 +60,11 @@
             <artifactId>mockito-core</artifactId>
             <version>1.10.19</version>
         </dependency>
-        <dependency>
-            <artifactId>guava</artifactId>
-            <groupId>com.google.guava</groupId>
-            <type>jar</type>
-            <version>14.0.1</version>
-        </dependency>
-    </dependencies>
-
+       <dependency>
+         <groupId>com.google.guava</groupId>
+         <artifactId>guava</artifactId>
+         <version>30.1-jre</version>
+       </dependency>
     <build>
         <sourceDirectory>src</sourceDirectory>
         <resources>


### PR DESCRIPTION
There is a security alert for guava, everything below 24.1.1 contains a vulnerability
i.e. https://github.com/advisories/GHSA-mvr2-9pj6-7w5j

I propose to update the version directly to the [latest release](https://github.com/google/guava/releases)  or at least 24.1.1. 

This affects the fortify plugin. Can someone make sure, that this update does not break it?